### PR TITLE
List non-English events on past events page

### DIFF
--- a/wp-content/plugins/do-action/includes/class-do-action.php
+++ b/wp-content/plugins/do-action/includes/class-do-action.php
@@ -989,7 +989,7 @@ class do_action {
 			'meta_key' => 'date',
 			'orderby' => 'meta_value',
 			'order' => 'DESC',
-			'lang' => 'en',
+			'lang' => '', // Show events from all locales
 			'posts_per_page' => -1,
 		);
 


### PR DESCRIPTION
Fixes https://doaction.org/past-events/ and show events without an English version.

This creates another issue of all language events showing on one list - but I'm not sure if there's a simple way to only show one of the versions.